### PR TITLE
add handling for inconsistent string/list returns

### DIFF
--- a/easyad.py
+++ b/easyad.py
@@ -164,6 +164,17 @@ def process_ldap_results(results, json_safe=False):
     return results
 
 
+def _listify(x):
+    """
+    Some servers send back inconsistently-typed fields, e.g. a single
+    string or a list of strings depending on the number of entries.
+    This function returns a list version of x if x is a non-string
+    iterable, otherwise returns a list with x as its only element,
+    which allows us to coerce such values into their type.
+    """
+    return [x] if isinstance(x, (type(b''), type(''))) else list(x)
+
+
 def enhance_user(user, json_safe=False):
     """
     Adds computed attributes to AD user results
@@ -176,7 +187,7 @@ def enhance_user(user, json_safe=False):
         An enhanced dictionary of user attributes
     """
     if "memberOf" in user.keys():
-        user["memberOf"] = sorted(user["memberOf"], key=lambda dn: dn.lower())
+        user["memberOf"] = sorted(_listify(user["memberOf"]), key=lambda dn: dn.lower())
     if "showInAddressBook" in user.keys():
         user["showInAddressBook"] = sorted(user["showInAddressBook"], key=lambda dn: dn.lower())
     if "lastLogonTimestamp" in user.keys():


### PR DESCRIPTION
I've found that the underling ldap library returns an inconsistently-typed result for "memberOf" when I use it agsinst my local Active Directory server.  When there's a single group, a string is returned, and we only return a list when there are either 0 or >1 groups.

I've added a new function call to coerce "memberOf" into a list prior to sorting it.